### PR TITLE
Update Dockerfile to include needed binary files

### DIFF
--- a/as-a-function/Dockerfile
+++ b/as-a-function/Dockerfile
@@ -17,3 +17,11 @@ RUN cp $(locate libjpeg.so.8 ) /poppler_binaries/.
 RUN cp $(locate libopenjp2.so.7 ) /poppler_binaries/.
 RUN cp $(locate libpng16.so.16 ) /poppler_binaries/.
 RUN cp $(locate libz.so.1 ) /poppler_binaries/.
+RUN cp $(locate libfreetype.so.6 ) /poppler_binaries/.
+RUN cp $(locate libfontconfig.so.1 ) /poppler_binaries/.
+RUN cp $(locate libnss3.so ) /poppler_binaries/.
+RUN cp $(locate libsmime3.so ) /poppler_binaries/.
+RUN cp $(locate liblcms2.so.2 ) /poppler_binaries/.
+RUN cp $(locate libtiff.so.5 ) /poppler_binaries/.
+RUN cp $(locate libexpat.so.1 ) /poppler_binaries/.
+RUN cp $(locate libjbig.so.0 ) /poppler_binaries/.


### PR DESCRIPTION
These binaries are required with python3.8